### PR TITLE
ffp-603: add unit-coverage action

### DIFF
--- a/go-service/unit-coverage.yml
+++ b/go-service/unit-coverage.yml
@@ -1,0 +1,42 @@
+name: unit-coverage
+on:
+  workflow_call:
+    inputs:
+      coverage-report:
+        required: true
+        type: string
+permissions:
+  contents: read
+
+jobs:
+  unit-coverage:
+    name: lint
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.18.0'
+          cache: true
+
+      - name: Setup github for go private
+        run: git config --global url.https://${{ secrets.SERVICE_HASTINGS_PAT }}@github.com/.insteadOf https://github.com/
+      
+      - uses: actions/download-artifact@v2
+        with:
+          name: coverage-report
+
+      - name: Quality check - Test Coverage
+        env: MIN_THRESHOLD: 90
+        run: |
+          echo "Minimum threshold: $MIN_THRESHOLD %"
+          totalCoverage=`go tool cover -func=profile.cov | grep total | grep -Eo '[0-9]+\.[0-9]+'’
+          if (( $(echo "$totalCoverage $MIN_THRESHOLD" | awk '{print ($1 > $2)}') )); then
+            echo "OK"
+          else
+            echo "Test Coverage is below threshold."
+            echo "Failed"
+            exit 1
+          fi


### PR DESCRIPTION
Change description:

- re-usable workflow which **_should_** be able to be called within the `test` workflow for repositories

Notes:

I confirm that:
- [ ] My code is secure
- [ ] My changes have tests
- [ ] I have documented my changes
- [ ] If this is a UI component, it adheres to the design documentation 
- [ ] My changes adhere to the [Fourth Floor Creative Engineering Standards and Principles](https://github.com/Fourth-Floor-Creative/engineering-standards#readme)
